### PR TITLE
fix: datasheet-accuracy audit + model 5 documented peripheral limitations

### DIFF
--- a/src/Avr8Sharp.TestKit/Boards/ATtiny85Simulation.cs
+++ b/src/Avr8Sharp.TestKit/Boards/ATtiny85Simulation.cs
@@ -71,9 +71,10 @@ public sealed class ATtiny85Simulation : AvrTestSimulation
         toie: 2, ociea: 16, ocieb: 8, ociec: 0);
 
     // ── ATtiny85 Timer 1 config ───────────────────────────────────────────────
-    // 8-bit TC1. Single control register TCCR1 at 0x30.
+    // 8-bit TC1. Single control register TCCR1 at I/O 0x30 → data-mem 0x50.
+    // (Mmio.Data is indexed by data-memory address = I/O offset + 0x20.)
     // TCCRA is mapped to address 0x00 (R0 — always 0 in well-behaved code → WGM = Normal mode).
-    // TCCRB is mapped to TCCR1 (0x30) so CS10–CS12 select the prescaler.
+    // TCCRB is mapped to TCCR1 (data-mem 0x50) so CS10–CS12 select the prescaler.
     // Prescalers for CS10:CS12 on ATtiny85 TC1:
     //   1→/1, 2→/2, 3→/4, 4→/8, 5→/16, 6→/32, 7→/64
     // TIFR (0x58) and TIMSK (0x59) are shared with Timer0; MmioController hook-chaining
@@ -89,11 +90,11 @@ public sealed class ATtiny85Simulation : AvrTestSimulation
         comparatorCInterrupt: 0,
         overflowInterrupt:    0x04,  // TIMER1_OVF vector
         tccra: 0x00,  // R0 — always 0 → forces Normal WGM mode
-        tccrb: 0x30,  // TCCR1 — contains CS13:CS10
+        tccrb: 0x50,  // TCCR1 — contains CS13:CS10 (I/O 0x30 → data-mem 0x50)
         tccrc: 0x00,
-        tcnt:  0x2F,  // TCNT1
-        ocra:  0x2E,  // OCR1A
-        ocrb:  0x2B,  // OCR1B
+        tcnt:  0x4F,  // TCNT1 (I/O 0x2F → data-mem 0x4F)
+        ocra:  0x4E,  // OCR1A (I/O 0x2E → data-mem 0x4E)
+        ocrb:  0x4B,  // OCR1B (I/O 0x2B → data-mem 0x4B)
         ocrc:  0,
         icr:   0,
         timsk: 0x59,  // shared TIMSK (Timer0 uses bits 0-2, Timer1 uses bits 4-6)

--- a/src/Avr8Sharp.TestKit/Boards/ATtiny85Simulation.cs
+++ b/src/Avr8Sharp.TestKit/Boards/ATtiny85Simulation.cs
@@ -118,7 +118,7 @@ public sealed class ATtiny85Simulation : AvrTestSimulation
     private static readonly AvrEepromConfig Tiny85EepromConfig = new AvrEepromConfig(
         eepromReadyInterrupt: 0x06,
         eecr: 0x3C, eedr: 0x3D, eearl: 0x3E, eearh: 0x00,
-        eraseCycles: 28800, writeCycles: 28800);
+        eraseCycles: 28800, writeCycles: 28800, atomicCycles: 54400);
 
     // ── GPIO ──────────────────────────────────────────────────────────────────
     /// <summary>

--- a/src/Avr8Sharp.TestKit/Boards/ArduinoMegaSimulation.cs
+++ b/src/Avr8Sharp.TestKit/Boards/ArduinoMegaSimulation.cs
@@ -162,7 +162,7 @@ public sealed class ArduinoMegaSimulation : AvrTestSimulation
     private static readonly AvrEepromConfig Mega2560EepromConfig = new AvrEepromConfig(
         eepromReadyInterrupt: 0x3C,
         eecr: 0x3F, eedr: 0x40, eearl: 0x41, eearh: 0x42,
-        eraseCycles: 28800, writeCycles: 28800);
+        eraseCycles: 28800, writeCycles: 28800, atomicCycles: 54400);
 
     // ── GPIO ports ────────────────────────────────────────────────────────────
     /// <summary>Port A — digital pins 22–29.</summary>

--- a/src/Avr8Sharp.TestKit/Boards/ArduinoMegaSimulation.cs
+++ b/src/Avr8Sharp.TestKit/Boards/ArduinoMegaSimulation.cs
@@ -157,9 +157,10 @@ public sealed class ArduinoMegaSimulation : AvrTestSimulation
     };
 
     // EEPROM — same I/O register addresses as ATmega328P; interrupt vector differs
-    // ATmega2560 EE_RDY: vector 30, byte addr 0x74, word addr 0x3A
+    // ATmega2560 EE_READY: avr-libc vect_num 30 → word addr 30×2 = 0x3C (byte 0x78).
+    // (0x3A is the ADC vector, vect_num 29 — do not confuse the two.)
     private static readonly AvrEepromConfig Mega2560EepromConfig = new AvrEepromConfig(
-        eepromReadyInterrupt: 0x3A,
+        eepromReadyInterrupt: 0x3C,
         eecr: 0x3F, eedr: 0x40, eearl: 0x41, eearh: 0x42,
         eraseCycles: 28800, writeCycles: 28800);
 

--- a/src/Avr8Sharp/Core/Opcodes.cs
+++ b/src/Avr8Sharp/Core/Opcodes.cs
@@ -848,13 +848,14 @@ public static class Opcodes
         var l = (opcode & 0xf) | ((opcode & 0xc0) >> 2);
         var R = a - l;
         cpu.Mmio.DataView.SetUint16((ushort)i, (ushort)R, true);
-        var sreg = 0;
+        // SBIW does not affect the H flag (AVR Instruction Set Manual: S V N Z C only),
+        // so preserve the existing H bit (0x20) rather than computing it.
+        var sreg = cpu._sregArith & 0x20;
         sreg |= R == 0 ? 2 : 0;
         sreg |= (0x8000 & R) != 0 ? 4 : 0;
         sreg |= (a & ~R & 0x8000) != 0 ? 8 : 0;
         sreg |= (((sreg >> 2) & 1) ^ ((sreg >> 3) & 1)) != 0 ? 0x10 : 0;
         sreg |= l > a ? 1 : 0;
-        sreg |= (8 & ((~a & l) | (l & R) | (R & ~a))) != 0 ? 0x20 : 0;
         cpu._sregArith = (byte)sreg;
         cpu.Cycles++;
     }

--- a/src/Avr8Sharp/Core/Peripherals/Adc.cs
+++ b/src/Avr8Sharp/Core/Peripherals/Adc.cs
@@ -193,15 +193,7 @@ public class AvrAdc
                     return true;
                 }
 
-                var channel = cpu.Mmio.Data[config.ADMUX] & MUX_MASK;
-                if ((cpu.Mmio.Data[config.ADCSRB] & MUX5) != 0)
-                {
-                    channel |= 0x20;
-                }
-
-                var muxInput = _muxArray[channel & 0x1F];
-                _converting = true;
-                OnADCRead(muxInput);
+                StartConversion();
                 return true;
             }
 
@@ -209,6 +201,43 @@ public class AvrAdc
         });
 
         UpdateCaches();
+    }
+
+    /// <summary>
+    /// Begins a conversion on the channel currently selected by ADMUX/MUX5, marking ADSC and
+    /// the internal converting state. Shared by the firmware-initiated path, free-running
+    /// auto-restart, and external auto-triggers.
+    /// </summary>
+    private void StartConversion()
+    {
+        _converting = true;
+        _cpu.Mmio.Data[_config.ADCSRA] |= ADSC;
+        var channel = _cpu.Mmio.Data[_config.ADMUX] & MUX_MASK;
+        if ((_cpu.Mmio.Data[_config.ADCSRB] & MUX5) != 0)
+        {
+            channel |= 0x20;
+        }
+
+        OnADCRead(_muxArray[channel & 0x1F]);
+    }
+
+    /// <summary>
+    /// Notifies the ADC that an auto-trigger event fired. When ADATE=1, the ADC is enabled,
+    /// no conversion is in progress, and <paramref name="source"/> matches the ADTS2:0 bits in
+    /// ADCSRB, a new conversion starts on the rising edge of the trigger (the call itself is the
+    /// edge). Free-running (ADTS=000) self-triggers via <see cref="CompleteAdcRead"/> and is not
+    /// driven here. Boards wire the relevant timer/comparator/external-interrupt event to this.
+    /// </summary>
+    public void Trigger(AdcTriggerSource source)
+    {
+        if (source == AdcTriggerSource.FreeRunning) return;
+
+        var adcsra = _cpu.Mmio.Data[_config.ADCSRA];
+        if ((adcsra & ADEN) == 0 || (adcsra & ADATE) == 0 || _converting) return;
+
+        if ((_cpu.Mmio.Data[_config.ADCSRB] & ADTS_MASK) != (int)source) return;
+
+        StartConversion();
     }
 
     public void OnADCRead(AdcMuxInput input)
@@ -251,18 +280,13 @@ public class AvrAdc
         _cpu.Mmio.Data[adcsra] &= ~ADSC & 0xff;
         _cpu.SetInterruptFlag(_adc);
 
-        // Auto-trigger: free-running mode (ADATE=1, ADTS=000 in ADCSRB)
+        // Auto-trigger: only free-running mode (ADATE=1, ADTS=000) restarts itself. Other
+        // trigger sources are edge-driven externally through Trigger().
         if ((_cpu.Mmio.Data[adcsra] & ADEN) != 0 &&
             (_cpu.Mmio.Data[adcsra] & ADATE) != 0 &&
             (_cpu.Mmio.Data[_config.ADCSRB] & ADTS_MASK) == 0)
         {
-            _converting = true;
-            var channel = _cpu.Mmio.Data[_config.ADMUX] & MUX_MASK;
-            if ((_cpu.Mmio.Data[_config.ADCSRB] & MUX5) != 0)
-            {
-                channel |= 0x20;
-            }
-            OnADCRead(_muxArray[channel & 0x1F]);
+            StartConversion();
         }
     }
 
@@ -307,6 +331,21 @@ public enum AdcMuxInputType
     Differential = 1,
     Constant = 2,
     Temperature = 3,
+}
+
+/// <summary>
+/// ADC auto-trigger sources, encoded as the ADTS2:0 bits in ADCSRB (ATmega328P §24.9.4).
+/// </summary>
+public enum AdcTriggerSource
+{
+    FreeRunning = 0,
+    AnalogComparator = 1,
+    ExternalInterrupt0 = 2,
+    Timer0CompareMatchA = 3,
+    Timer0Overflow = 4,
+    Timer1CompareMatchB = 5,
+    Timer1Overflow = 6,
+    Timer1CaptureEvent = 7,
 }
 
 public class AdcMuxInput(

--- a/src/Avr8Sharp/Core/Peripherals/Clock.cs
+++ b/src/Avr8Sharp/Core/Peripherals/Clock.cs
@@ -8,12 +8,16 @@ public class AvrClock
 
     public static readonly AvrClockConfig ClockConfig = new AvrClockConfig(0x61);
 
+    // CLKPS3:0 → system clock division factor. Indices 0..8 are the datasheet-defined
+    // factors 1,2,4,…,256 (ATmega328P Table 13-12). Indices 9..15 are marked "Reserved" by
+    // the datasheet — their behaviour is undefined and firmware must not select them. The
+    // values below were measured on real ATmega328P silicon, where the divider follows the
+    // pattern 2^(index-8) (i.e. 2,4,…,128) in that region; they are kept because empirical
+    // hardware behaviour is the closest thing to a source of truth for an undefined region.
     public static readonly int[] Prescalers =
     [
         1, 2, 4, 8, 16, 32, 64, 128, 256,
-
-        // The following values are "reserved" according to the datasheet, so we measured
-        // with a scope to figure them out (on ATmega328p)
+        // Reserved region (empirical ATmega328P measurements — see note above):
         2, 4, 8, 16, 32, 64, 128,
     ];
 

--- a/src/Avr8Sharp/Core/Peripherals/Eeprom.cs
+++ b/src/Avr8Sharp/Core/Peripherals/Eeprom.cs
@@ -18,8 +18,9 @@ public class AvrEeprom
         eedr: 0x40,
         eearl: 0x41,
         eearh: 0x42,
-        eraseCycles: 28800,
-        writeCycles: 28800
+        eraseCycles: 28800,   // 1.8 ms at 16 MHz (erase-only)
+        writeCycles: 28800,   // 1.8 ms at 16 MHz (write-only)
+        atomicCycles: 54400   // 3.4 ms at 16 MHz (atomic erase+write, datasheet Table 7-1)
     );
 
     private ulong _writeEnabledCycles = 0;
@@ -91,18 +92,28 @@ public class AvrEeprom
                 var capturedAddr = (ushort)((cpu.Mmio.Data[_config.EEARH] << 8) | cpu.Mmio.Data[_config.EEARL]);
                 var capturedData = cpu.Mmio.Data[_config.EEDR];
 
-                var duration = 0;
                 var doErase = (eecr & EEPM1) == 0;
                 var doWrite = (eecr & EEPM0) == 0;
-
-                if (doErase) duration += (int)_config.EraseCycles;
-                if (doWrite) duration += (int)_config.WriteCycles;
 
                 // EEPM=11 is reserved/undefined per ATmega datasheet — treat as no-op
                 if (!doErase && !doWrite)
                 {
                     cpu.Mmio.Data[_config.EECR] &= ~EEPE & 0xFF;
                     return true;
+                }
+
+                int duration;
+                if (doErase && doWrite && _config.AtomicCycles > 0)
+                {
+                    // Atomic erase+write completes faster than the two operations run back to
+                    // back (3.4 ms vs 1.8 + 1.8 = 3.6 ms) because the hardware overlaps them.
+                    duration = (int)_config.AtomicCycles;
+                }
+                else
+                {
+                    duration = 0;
+                    if (doErase) duration += (int)_config.EraseCycles;
+                    if (doWrite) duration += (int)_config.WriteCycles;
                 }
 
                 _writeCompleteCycles = cpu.Cycles + (ulong)duration;
@@ -181,7 +192,8 @@ public class AvrEepromConfig(
     byte eearl = 0,
     byte eearh = 0,
     uint eraseCycles = 0,
-    uint writeCycles = 0)
+    uint writeCycles = 0,
+    uint atomicCycles = 0)
 {
     public readonly byte EepromReadyInterrupt = eepromReadyInterrupt;
 
@@ -192,4 +204,10 @@ public class AvrEepromConfig(
 
     public readonly uint EraseCycles = eraseCycles;
     public readonly uint WriteCycles = writeCycles;
+
+    /// <summary>
+    /// Duration of an atomic erase+write (EEPM=00). When 0, the atomic time falls back to
+    /// <see cref="EraseCycles"/> + <see cref="WriteCycles"/>.
+    /// </summary>
+    public readonly uint AtomicCycles = atomicCycles;
 }

--- a/src/Avr8Sharp/Core/Peripherals/Gpio.cs
+++ b/src/Avr8Sharp/Core/Peripherals/Gpio.cs
@@ -46,7 +46,7 @@ public class AvrIoPort
 		pcie: 2,
 		pcicr: 0x68,
 		pcifr: 0x3b,
-		pcmsk: 0x6c,
+		pcmsk: 0x6d,
 		pinChangeInterrupt: 10,
 		mask: 0xFF,
 		offset: 0

--- a/src/Avr8Sharp/Core/Peripherals/Twi.cs
+++ b/src/Avr8Sharp/Core/Peripherals/Twi.cs
@@ -41,6 +41,7 @@ public class AvrTwi
     const int STATUS_SLAVE_GCALL_ACK = 0x70;     // General call received, ACK returned
     const int STATUS_SLAVE_DATA_RX_ACK = 0x80;   // Data byte received, ACK returned
     const int STATUS_SLAVE_DATA_RX_NACK = 0x88;  // Data byte received, NACK returned
+    const int STATUS_SLAVE_STOP = 0xA0;          // STOP or repeated START received while addressed as slave (TW_SR_STOP)
     // Slave transmit states
     const int STATUS_SLAVE_SLAR_ACK = 0xA8;      // SLA+R received, ACK returned
 
@@ -254,6 +255,15 @@ public class AvrTwi
         var ack = (_cpu.Mmio.Data[_config.TWCR] & TWCR_TWEA) != 0;
         UpdateStatus (ack ? STATUS_SLAVE_DATA_RX_ACK : STATUS_SLAVE_DATA_RX_NACK);
     }
+
+    /// <summary>
+    /// Simulate a STOP (or repeated START) condition from the external master while
+    /// this device is addressed as slave. Sets TWSR to 0xA0 (TW_SR_STOP) and raises
+    /// TWINT — this is the status on which the Arduino Wire library's ISR fires the
+    /// user's onReceive callback, so slave-receiver firmware cannot complete a
+    /// transaction without it.
+    /// </summary>
+    public void SimulateIncomingStop () => UpdateStatus (STATUS_SLAVE_STOP);
 
     /// <summary>
     /// Read the byte firmware placed in TWDR for slave-transmit mode.

--- a/src/Avr8Sharp/Core/Peripherals/Usart.cs
+++ b/src/Avr8Sharp/Core/Peripherals/Usart.cs
@@ -25,6 +25,7 @@ public class AvrUsart
     const int UCSRB_CFG_MASK = UCSRB_UCSZ2 | UCSRB_RXEN | UCSRB_TXEN;
     const int UCSRC_UMSEL1 = 0x80; // USART Mode Select 1
     const int UCSRC_UMSEL0 = 0x40; // USART Mode Select 0
+    const int UCSRC_UMSEL_MASK = UCSRC_UMSEL1 | UCSRC_UMSEL0;
     const int UCSRC_UPM1 = 0x20; // Parity Mode 1
     const int UCSRC_UPM0 = 0x10; // Parity Mode 0
     const int UCSRC_USBS = 0x08; // Stop Bit Select
@@ -73,6 +74,8 @@ public class AvrUsart
     private readonly Action _txCompleteAction;
     private readonly Action _rxCompleteAction;
     private ushort _incomingRxBuffer;
+    private bool _incomingFrameError;
+    private bool _incomingParityError;
 
     public Action<byte>? OnByteTransmit { get; set; } = null;
     public Action<string>? OnLineTransmit { get; set; } = null;
@@ -98,9 +101,24 @@ public class AvrUsart
         get { return _cpu.Mmio.Data[_config.UBRRL] | _cpu.Mmio.Data[_config.UBRRH] << 8; }
     }
 
+    /// <summary>
+    /// True when the USART is in synchronous master mode (UMSEL1:0 = 01). In this mode
+    /// the baud divisor is f/(2·(UBRR+1)) and the U2X bit is ignored.
+    /// </summary>
+    public bool SyncMode
+    {
+        get { return (_cpu.Mmio.Data[_config.UCSRC] & UCSRC_UMSEL_MASK) == UCSRC_UMSEL0; }
+    }
+
     public int Multiplier
     {
-        get { return (_cpu.Mmio.Data[_config.UCSRA] & UCSRA_U2X) != 0 ? 8 : 16; }
+        get
+        {
+            // Synchronous mode: fixed divisor of 2 (datasheet §19.3.1). Async normal = 16,
+            // async double-speed (U2X) = 8.
+            if (SyncMode) return 2;
+            return (_cpu.Mmio.Data[_config.UCSRA] & UCSRA_U2X) != 0 ? 8 : 16;
+        }
     }
 
     public bool RxEnable
@@ -196,7 +214,7 @@ public class AvrUsart
         _rxCompleteAction = () =>
         {
             _rxBusyValue = false;
-            WriteByte(_incomingRxBuffer, true);
+            WriteByte(_incomingRxBuffer, true, _incomingFrameError, _incomingParityError);
         };
         
         Reset();
@@ -254,6 +272,10 @@ public class AvrUsart
         {
             var result = _rxBuffer & _cachedRxMask & 0xFF;
             _rxBuffer = 0;
+            // FE/DOR/UPE are tied to the word in the receive buffer; reading UDR consumes
+            // that word, so the error flags are cleared (in a deeper FIFO they would update
+            // to the next word's status — here the single buffered word is now empty).
+            _cpu.Mmio.Data[_config.UCSRA] &= unchecked((byte)~(UCSRA_FE | UCSRA_DOR | UCSRA_UPE));
             _cpu.ClearInterrupt(_rxc);
             return (byte)result;
         });
@@ -316,13 +338,35 @@ public class AvrUsart
         _lineBuffer.Clear();
     }
 
-    public bool WriteByte(ushort value, bool immediate = false)
+    /// <summary>
+    /// Delivers a received byte to the USART. <paramref name="frameError"/> models a stop-bit
+    /// violation (FE) and <paramref name="parityError"/> a parity mismatch (UPE) for the frame.
+    /// If a previously received byte has not yet been read from UDR, the new byte is lost and
+    /// the Data OverRun flag (DOR) is set, per the datasheet.
+    /// </summary>
+    public bool WriteByte(ushort value, bool immediate = false, bool frameError = false, bool parityError = false)
     {
         if (_rxBusyValue || !RxEnable) return false;
 
         if (immediate)
         {
+            // Overrun: a frame completed while the previous one is still unread (RXC set).
+            // The buffered word is kept and the incoming word is discarded; DOR is raised.
+            if ((_cpu.Mmio.Data[_config.UCSRA] & UCSRA_RXC) != 0)
+            {
+                _cpu.Mmio.Data[_config.UCSRA] |= UCSRA_DOR;
+                OnRxComplete?.Invoke();
+                return false;
+            }
+
             _rxBuffer = value;
+
+            // Frame Error / Parity Error accompany this word in the receive buffer and stay
+            // valid until UDR is read. They are read-only to firmware, so set them directly.
+            var ucsra = _cpu.Mmio.Data[_config.UCSRA];
+            ucsra = frameError ? (byte)(ucsra | UCSRA_FE) : (byte)(ucsra & ~UCSRA_FE);
+            ucsra = parityError ? (byte)(ucsra | UCSRA_UPE) : (byte)(ucsra & ~UCSRA_UPE);
+            _cpu.Mmio.Data[_config.UCSRA] = ucsra;
 
             var ucsrb = _cpu.Mmio.Data[_config.UCSRB];
             if ((value & 0x100) != 0)
@@ -342,6 +386,8 @@ public class AvrUsart
         {
             _rxBusyValue = true;
             _incomingRxBuffer = value;
+            _incomingFrameError = frameError;
+            _incomingParityError = parityError;
             _cpu.AddClockEvent(_rxCompleteAction, _cachedCyclesPerChar);
         }
 

--- a/tests/Avr8Sharp.Tests/AdcTests.cs
+++ b/tests/Avr8Sharp.Tests/AdcTests.cs
@@ -162,9 +162,11 @@ public class Adc : AvrTestBase
 
         Assert.Multiple(() =>
         {
-            // Check ADIF is set (conversion complete), ADSC is clear
+            // ADIF set on completion. In free-running mode the next conversion starts
+            // immediately, so ADSC reads 1 again (a conversion is in progress), per the
+            // datasheet ("ADSC reads as one as long as a conversion is in progress").
             Assert.That(Cpu.Mmio.Data[ADCSRA] & ADIF, Is.EqualTo(ADIF), "ADIF should be set after first conversion");
-            Assert.That(Cpu.Mmio.Data[ADCSRA] & ADSC, Is.EqualTo(0), "ADSC should be clear after conversion completes");
+            Assert.That(Cpu.Mmio.Data[ADCSRA] & ADSC, Is.EqualTo(ADSC), "ADSC stays set: free-running immediately starts the next conversion");
         });
 
         // In free-running mode, a second conversion should have been queued automatically.
@@ -203,6 +205,33 @@ public class Adc : AvrTestBase
 
 		Assert.That(Cpu.Mmio.Data[ADCSRA] & ADIF, Is.EqualTo(0),
 			"ADIF must NOT fire again when ADATE=0 (single-conversion mode)");
+	}
+
+	[Test(Description = "ADC auto-trigger: Trigger() starts a conversion only for the ADTS-selected source when ADATE=1")]
+	public void AutoTrigger_StartsOnMatchingSource ()
+	{
+		const int ADCSRB = 0x7b;
+		_adc.ChannelValues[0] = 2.56;
+		Cpu.Mmio.Data[ADMUX] = REFS0;
+		Cpu.Mmio.Data[ADCSRB] = 0x03;                            // ADTS = 011 → Timer0 Compare Match A
+		Cpu.WriteData (ADCSRA, ADEN | ADATE | ADPS0 | ADPS1 | ADPS2); // enabled, auto-trigger, NO ADSC
+
+		// Nothing converts until a trigger arrives.
+		Cpu.Cycles += 128 * 25;
+		Cpu.Tick();
+		Assert.That (Cpu.Mmio.Data[ADCSRA] & ADIF, Is.EqualTo(0), "no conversion before any trigger");
+
+		// A source that does not match ADTS is ignored.
+		_adc.Trigger (AdcTriggerSource.Timer1Overflow);
+		Assert.That (Cpu.Mmio.Data[ADCSRA] & ADSC, Is.EqualTo(0), "non-matching source must not start a conversion");
+
+		// The matching source starts a conversion (ADSC goes high).
+		_adc.Trigger (AdcTriggerSource.Timer0CompareMatchA);
+		Assert.That (Cpu.Mmio.Data[ADCSRA] & ADSC, Is.EqualTo(ADSC), "matching source must start a conversion");
+
+		Cpu.Cycles += 128 * 25;
+		Cpu.Tick();
+		Assert.That (Cpu.Mmio.Data[ADCSRA] & ADIF, Is.EqualTo(ADIF), "ADIF set after the triggered conversion completes");
 	}
 
 	[Test (Description = "AvrAdc.TemperatureVoltage is configurable and affects the ADC result")]

--- a/tests/Avr8Sharp.Tests/ClockTests.cs
+++ b/tests/Avr8Sharp.Tests/ClockTests.cs
@@ -55,6 +55,25 @@ public class Clock : AvrTestBase
 		});
 	}
 	
+	[Test (Description = "Reserved CLKPS values (9-15) follow the empirical 328P pattern 2^(index-8)")]
+	public void ReservedPrescalerValues ()
+	{
+		// Index 9 is datasheet-reserved; on real 328P silicon it divides by 2. This locks in
+		// the documented empirical behaviour for the undefined region.
+		Cpu.WriteData (CLKPC, CLKPCE);
+		Cpu.WriteData (CLKPC, 9);
+		Assert.Multiple(() =>
+		{
+			Assert.That(_clock.Prescaler, Is.EqualTo(2));
+			Assert.That(_clock.Frequency, Is.EqualTo(8_000_000)); // 16MHz / 2
+		});
+
+		// Index 15 divides by 128 (2^(15-8)).
+		Cpu.WriteData (CLKPC, CLKPCE);
+		Cpu.WriteData (CLKPC, 15);
+		Assert.That(_clock.Prescaler, Is.EqualTo(128));
+	}
+
 	[Test (Description = "Should return the current prescaler value")]
 	public void PrescalerValue ()
 	{

--- a/tests/Avr8Sharp.Tests/EepromTests.cs
+++ b/tests/Avr8Sharp.Tests/EepromTests.cs
@@ -113,6 +113,32 @@ public class Eeprom : AvrTestBase
 			});
 		}
 		
+		[Test (Description = "Atomic erase+write (EEPM=00) completes in 3.4ms (54400 cy), not 1.8+1.8=3.6ms (57600 cy)")]
+		public void AtomicWriteTiming ()
+		{
+			Cpu.WriteData (EEDR, 0x55);
+			Cpu.WriteData (EEARL, 15);
+			Cpu.WriteData (EEARH, 0);
+			Cpu.WriteData (EECR, EEMPE);
+			Cpu.WriteData (EECR, EEPE); // EEPM=00 → atomic erase+write
+			Cpu.Tick ();
+
+			// At 54002 cycles the write is still in progress (true for both 3.4ms and 3.6ms).
+			Cpu.Cycles += 54000;
+			Cpu.Tick ();
+			Assert.That (Cpu.Mmio.Data[EECR] & EEPE, Is.EqualTo(EEPE), "still writing just before 3.4ms");
+
+			// At 55002 cycles it must be complete (3.4ms=54400). With the old 3.6ms (57600)
+			// it would still be writing here, so this pins the atomic timing to 3.4ms.
+			Cpu.Cycles += 1000;
+			Cpu.Tick ();
+			Assert.Multiple(() =>
+			{
+				Assert.That (_backend.ReadMemory (15), Is.EqualTo(0x55), "atomic write done by 3.4ms");
+				Assert.That (Cpu.Mmio.Data[EECR] & EEPE, Is.EqualTo(0), "EEPE cleared on completion");
+			});
+		}
+
 		[Test (Description = "Should not erase the memory when writing if EEPM1 is high")]
 		public void NoErase ()
 		{

--- a/tests/Avr8Sharp.Tests/InstructionTest.cs
+++ b/tests/Avr8Sharp.Tests/InstructionTest.cs
@@ -1182,18 +1182,22 @@ public class Instruction : AvrTestBase
 		});
 	}
 
-	[Test (Description = "SBIW: half-carry set on nibble borrow (regression: 1& vs 8&)")]
-	public void SBIW_HalfCarry ()
+	[Test (Description = "SBIW: does NOT affect the H flag (manual: only S,V,N,Z,C) and preserves a pre-set H")]
+	public void SBIW_DoesNotAffectHalfCarry ()
 	{
+		// AVR Instruction Set Manual, SBIW: the H flag is unchanged. 0x0010 - 8 = 0x0008
+		// (positive, non-zero, no borrow, no overflow) → S,V,N,Z,C all clear. H must keep
+		// whatever value it had; here we pre-set H to prove SBIW leaves it untouched.
 		LoadProgram ([ "sbiw r24, 8" ]);
 		Cpu.Mmio.Data[R24] = 0x10;
-		Cpu.Mmio.Data[R25] = 0x00;   // r25:r24 = 0x0010; 0x0010 - 8 = 0x0008, borrow at bit 3 → H=1
+		Cpu.Mmio.Data[R25] = 0x00;   // r25:r24 = 0x0010
+		Cpu.WriteData (95, SREG_H);   // pre-set H via SREG hook; SBIW must not clear it
 		decoder.Decode(Cpu);
 		Assert.Multiple(() =>
 		{
 			Assert.That (Cpu.Mmio.Data[R24], Is.EqualTo (0x08));
 			Assert.That (Cpu.Mmio.Data[R25], Is.EqualTo (0x00));
-			Assert.That (Cpu.Sreg, Is.EqualTo (SREG_H));
+			Assert.That (Cpu.Sreg, Is.EqualTo (SREG_H), "SBIW must leave H untouched and set no other flag");
 		});
 	}
 

--- a/tests/Avr8Sharp.Tests/TwiTests.cs
+++ b/tests/Avr8Sharp.Tests/TwiTests.cs
@@ -614,6 +614,29 @@ public class Twi : AvrTestBase
             });
         }
 
+        [Test(Description = "Slave receive: SimulateIncomingStop sets TWSR=0xA0 (TW_SR_STOP) and raises TWINT")]
+        public void SlaveReceive_StopCompletesTransaction()
+        {
+            const int STATUS_SLAVE_STOP = 0xA0;
+
+            Cpu.Mmio.Data[TWAR] = (byte)(0x48 << 1);
+            Cpu.WriteData((ushort)TWCR, (byte)(TWEN | TWEA | TWINT));
+
+            // SLA+W (0x60) → data (0x80) → STOP (0xA0): the full slave-receiver sequence.
+            _twi.SimulateIncomingAddress(0x48, isWrite: true);
+            Cpu.WriteData((ushort)TWCR, (byte)(TWEN | TWEA | TWINT));
+            _twi.SimulateIncomingData(0x5A);
+            Cpu.WriteData((ushort)TWCR, (byte)(TWEN | TWEA | TWINT));
+            _twi.SimulateIncomingStop();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Cpu.Mmio.Data[TWSR] & TWSR_TWS_MASK, Is.EqualTo(STATUS_SLAVE_STOP),
+                    "TWSR must be 0xA0 (STOP/repeated START received while addressed as slave)");
+                Assert.That(Cpu.Mmio.Data[TWCR] & TWINT, Is.EqualTo(TWINT), "TWINT must be set");
+            });
+        }
+
         [Test(Description = "General call: TWINT is set and TWSR=0x70 when TWAR bit0=1 and address=0x00")]
         public void GeneralCall_WhenEnabled()
         {

--- a/tests/Avr8Sharp.Tests/UsartTests.cs
+++ b/tests/Avr8Sharp.Tests/UsartTests.cs
@@ -30,6 +30,11 @@ public class Usart : AvrTestBase
 	const int USBS = 0x08;
 	const int UPM0 = 0x10;
 	const int UPM1 = 0x20;
+	const int FE = 0x10;     // Frame Error (UCSRA)
+	const int DOR = 0x08;    // Data OverRun (UCSRA)
+	const int UPE = 0x04;    // Parity Error (UCSRA)
+	const int UMSEL0 = 0x40; // USART Mode Select 0 (UCSRC) — synchronous when set, async clear
+	const int UCSZ_8BIT = 0x06; // UCSZ1|UCSZ0 = 8-bit frame (UCSRC default)
 
 	// Interrupt address
 	const int PC_INT_UDRE = 0x26;
@@ -65,7 +70,22 @@ public class Usart : AvrTestBase
 		
 		Assert.That (_usart.BaudRate, Is.EqualTo(2_400));
 	}
-	
+
+	[Test(Description = "Synchronous master mode (UMSEL=01): baud = f/(2*(UBRR+1)), U2X ignored")]
+	public void BaudRateCalculationSynchronous()
+	{
+		Cpu.WriteData (UCSR0C, UMSEL0 | UCSZ_8BIT); // synchronous master, 8-bit
+		Cpu.WriteData (UBRR0H, 0);
+		Cpu.WriteData (UBRR0L, 3);                  // 16MHz / (2*(3+1)) = 2,000,000
+
+		Assert.Multiple(() =>
+		{
+			Assert.That (_usart.SyncMode, Is.True);
+			Assert.That (_usart.Multiplier, Is.EqualTo(2));
+			Assert.That (_usart.BaudRate, Is.EqualTo(2_000_000));
+		});
+	}
+
 	[Test(Description = "Should call onConfigurationChange when the baudRate changes")]
 	public void ConfigurationChange()
 	{
@@ -411,6 +431,61 @@ public class Usart : AvrTestBase
 			Cpu.Tick();
 			
 			Assert.That (usart.WriteByte(10), Is.False);
+		}
+	}
+
+	[TestFixture]
+	public class ReceiveErrors : AvrTestBase
+	{
+		private AvrUsart _usart;
+
+		protected override void SetupPeripherals()
+		{
+			_usart = new AvrUsart(Cpu, AvrUsart.Usart0Config, FREQ_16MHZ);
+		}
+
+		[Test(Description = "Frame Error (FE) is set for a malformed frame and cleared after UDR is read")]
+		public void FrameError()
+		{
+			Cpu.WriteData (UCSR0B, RXEN);
+			_usart.WriteByte(0x42, immediate: true, frameError: true);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That (Cpu.Mmio.Data[UCSR0A] & FE, Is.EqualTo(FE), "FE must be set");
+				Assert.That (Cpu.Mmio.Data[UCSR0A] & RXC, Is.EqualTo(RXC), "RXC must be set");
+			});
+
+			Cpu.ReadData (UDR0);
+			Assert.That (Cpu.Mmio.Data[UCSR0A] & FE, Is.EqualTo(0), "FE must clear after reading UDR");
+		}
+
+		[Test(Description = "Parity Error (UPE) is set for a frame with bad parity")]
+		public void ParityError()
+		{
+			Cpu.WriteData (UCSR0B, RXEN);
+			_usart.WriteByte(0x42, immediate: true, parityError: true);
+
+			Assert.That (Cpu.Mmio.Data[UCSR0A] & UPE, Is.EqualTo(UPE), "UPE must be set");
+		}
+
+		[Test(Description = "Data OverRun (DOR): a byte arriving before UDR is read is lost and sets DOR")]
+		public void DataOverRun()
+		{
+			Cpu.WriteData (UCSR0B, RXEN);
+			_usart.WriteByte(0x11, immediate: true); // first byte, RXC set
+
+			var second = _usart.WriteByte(0x22, immediate: true); // overrun: not yet read
+
+			Assert.Multiple(() =>
+			{
+				Assert.That (second, Is.False, "overrun byte must be rejected");
+				Assert.That (Cpu.Mmio.Data[UCSR0A] & DOR, Is.EqualTo(DOR), "DOR must be set");
+			});
+
+			// The first byte is preserved; the overrun byte was discarded.
+			Assert.That (Cpu.ReadData (UDR0), Is.EqualTo(0x11), "buffered byte must survive the overrun");
+			Assert.That (Cpu.Mmio.Data[UCSR0A] & DOR, Is.EqualTo(0), "DOR clears after reading UDR");
 		}
 	}
 


### PR DESCRIPTION
Validates AVR8Sharp against the **source of truth** (Microchip/Atmel datasheets + avr-libc headers `iom*.h`/`iotn*.h`), accounting for the three simulated chips (ATmega328P, ATmega2560, ATtiny85). avr8js was used only as a reference for intent — **no code was copied** and no GPL sources were used.

## Accuracy fixes (validated against datasheet)

| File | Bug | Fix |
|---|---|---|
| `Gpio.cs` | PCINT2 `PCMSK2 = 0x6c` (that is PCMSK1) | → `0x6d` |
| `ArduinoMegaSimulation.cs` | EEPROM `EE_READY = 0x3A` (the ADC vector) | → `0x3C` (vect 30 × 2) |
| `ATtiny85Simulation.cs` | Timer1 (TC1) used I/O offsets (collided with USI) | → data-memory `0x50/0x4F/0x4E/0x4B` |
| `Opcodes.cs` | `SBIW` wrote the H flag | preserves H (manual: only S,V,N,Z,C); test rewritten |

Audit false positives (verified correct against avr-libc headers and dismissed): the 38 Mega timer/USART vectors (`word = vect_num × 2` rule), the USI registers, every WGM/prescaler table in `Timer.cs`, and all flag formulas except SBIW.

Also: `feat(twi)` completes the slave-receiver sequence with `TW_SR_STOP` (0xA0) plus test coverage.

## Modeled the 5 documented peripheral limitations

1. **Synchronous USART** (UMSEL=01): baud divisor `f/(2·(UBRR+1))`, `U2X` ignored, plus a `SyncMode` property.
2. **USART FE/DOR/UPE**: `WriteByte` carries `frameError`/`parityError`, **DOR** is raised on overrun, and the flags are cleared when UDR is read. *(Models the current buffer depth, not the 2-level FIFO — documented in code.)*
3. **ADC auto-triggers**: `AdcTriggerSource` enum (ADTS2:0) plus a `Trigger(source)` entry point, edge-gated and ADATE-gated; free-running keeps self-restarting; ADSC reads 1 during a conversion.
4. **EEPROM atomic 3.4 ms**: `atomicCycles = 54400` (vs. 1.8 + 1.8 = 3.6 ms), across all 3 configs.
5. **Reserved clock CLKPS region** (9–15): the datasheet leaves it undefined, so the real empirical 328P values are preserved (as faithful as possible) — documented and locked with a regression test.

## Verification

**423 tests + 16 samples, all passing** (+9 new tests). Every change is cited against a Microchip datasheet or avr-libc header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
