### PR TITLE
chore(license): relicense TestKit under BUSL-1.1 (1.1.0-beta5)

### DIFF
--- a/LICENSE-BUSL.txt
+++ b/LICENSE-BUSL.txt
@@ -1,0 +1,102 @@
+Business Source License 1.1
+
+Parameters
+
+Licensor:             Iván Montiel Cardona
+Licensed Work:        AVR8Sharp BUSL-1.1 components — Avr8Sharp.TestKit and
+                      Avr8Sharp.TestKit.Core.
+                      (The Avr8Sharp simulator core is licensed separately under
+                      MIT; it is a port of the avr8js library, © Uri Shaked.)
+                      The Licensed Work is © 2025-2026 Iván Montiel Cardona.
+Additional Use Grant: You may copy, modify, redistribute, and make production use of
+                      the Licensed Work free of charge for any purpose that is not a
+                      Commercial Use.
+
+                      "Commercial Use" means either:
+                        (a) using the Licensed Work in an automated build, test,
+                            continuous-integration, or continuous-delivery (CI/CD)
+                            system that is operated by or on behalf of a for-profit
+                            organization; or
+                        (b) using or incorporating the Licensed Work in the
+                            development, testing, distribution, or operation of any
+                            product or service that generates, or is intended to
+                            generate, commercial revenue.
+
+                      Use by individuals, and use for personal, hobby, educational,
+                      academic-research, evaluation, or open-source purposes, is never
+                      a Commercial Use and is always permitted free of charge.
+
+                      Commercial Use requires a separate commercial license from the
+                      Licensor.
+Change Date:          2030-07-08
+Change License:       MIT
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact the Licensor.
+
+-----------------------------------------------------------------------------
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production
+use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under the
+terms of the Change License, and the rights granted in the paragraph above
+terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently
+in effect as described in this License, you must purchase a commercial license
+from the Licensor, its affiliated entities, or authorized resellers, or you must
+refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of
+the Licensed Work, are subject to this License. This License applies separately
+for each version of the Licensed Work and the Change Date may vary for each
+version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of
+the Licensed Work. If you receive the Licensed Work in original or modified form
+from a third party, the terms and conditions set forth in this License apply to
+your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or
+its affiliates (provided that you may use a trademark or logo of Licensor as
+expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
+"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license your
+works, and to refer to it using the trademark "Business Source License", as long
+as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business Source
+License" name and trademark, Licensor covenants to MariaDB, and to all other
+recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version, or
+   a license that is compatible with GPL Version 2.0 or a later version, where
+   "compatible" means that software provided under the Change License can be
+   included in a program with software provided under GPL Version 2.0 or a later
+   version. Licensor may specify additional Change Licenses without limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as the
+   Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.

--- a/src/Avr8Sharp.TestKit.Core/Avr8Sharp.TestKit.Core.csproj
+++ b/src/Avr8Sharp.TestKit.Core/Avr8Sharp.TestKit.Core.csproj
@@ -18,8 +18,11 @@
         <Copyright>Copyright (c) Iván Montiel</Copyright>
         <RepositoryUrl>https://github.com/begeistert/avr8sharp</RepositoryUrl>
         <PackageTags>Arduino;AVR;Simulator;Testing</PackageTags>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.1.0-beta4</Version>
+        <!-- Specialized work: Business Source License 1.1 (converts to MIT on the Change Date).
+             nuget.org rejects BUSL-1.1 as a license *expression*, so we ship it as a *file*. -->
+        <PackageLicenseExpression></PackageLicenseExpression>
+        <PackageLicenseFile>LICENSE-BUSL.txt</PackageLicenseFile>
+        <Version>1.1.0-beta5</Version>
         <PackageProjectUrl>https://github.com/begeistert/avr8sharp</PackageProjectUrl>
         <Company>Iván Montiel</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -27,6 +30,7 @@
 
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\LICENSE-BUSL.txt" Pack="true" PackagePath="" Visible="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Avr8Sharp.TestKit/Avr8Sharp.TestKit.csproj
+++ b/src/Avr8Sharp.TestKit/Avr8Sharp.TestKit.csproj
@@ -13,8 +13,11 @@
         <Copyright>Copyright (c) Iván Montiel</Copyright>
         <RepositoryUrl>https://github.com/begeistert/avr8sharp</RepositoryUrl>
         <PackageTags>Arduino;AVR;Simulator;Testing;FluentAssertions</PackageTags>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.1.0-beta4</Version>
+        <!-- Specialized work: Business Source License 1.1 (converts to MIT on the Change Date).
+             nuget.org rejects BUSL-1.1 as a license *expression*, so we ship it as a *file*. -->
+        <PackageLicenseExpression></PackageLicenseExpression>
+        <PackageLicenseFile>LICENSE-BUSL.txt</PackageLicenseFile>
+        <Version>1.1.0-beta5</Version>
         <PackageProjectUrl>https://github.com/begeistert/avr8sharp</PackageProjectUrl>
         <Company>Iván Montiel</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -34,6 +37,7 @@
 
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\LICENSE-BUSL.txt" Pack="true" PackagePath="" Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/src/Avr8Sharp/Avr8Sharp.csproj
+++ b/src/Avr8Sharp/Avr8Sharp.csproj
@@ -15,7 +15,7 @@
         <RepositoryUrl>https://github.com/begeistert/avr8sharp</RepositoryUrl>
         <PackageTags>Arduino;AVR;Simulator</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.1.0-beta4</Version>
+        <Version>1.1.0-beta5</Version>
         <PackageProjectUrl>https://github.com/begeistert/avr8sharp</PackageProjectUrl>
         <Company>Iván Montiel</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
## Relicense TestKit to BUSL-1.1

Moves the value-add test kits to the **Business Source License 1.1** while keeping the emulator **core MIT**.

| Package | Before | After |
|---|---|---|
| `Avr8Sharp` (core) | MIT | **MIT** (unchanged — port of avr8js, © Uri Shaked) |
| `Avr8Sharp.TestKit` | MIT | **BUSL-1.1** |
| `Avr8Sharp.TestKit.Core` | MIT | **BUSL-1.1** |

- BUSL-1.1 converts to MIT on the Change Date (**2030-07-08**).
- Non-commercial / personal / educational / OSS use stays free of charge.
- nuget.org rejects `BUSL-1.1` as an SPDX expression, so the license ships as a packaged file (`LICENSE-BUSL.txt`).
- Version bumped to **1.1.0-beta5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)