### PR TITLE
chore(license): whole project BUSL-1.1 incl. core (1.1.0-beta7)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,18 @@
-The MIT License (MIT)
+AVR8Sharp is licensed under the Business Source License 1.1 (BUSL-1.1).
+
+The full license text and parameters are in LICENSE-BUSL.txt. In summary: the
+entire project is initially BUSL-1.1 and automatically converts to the MIT
+License (the Change License) on the Change Date. Non-commercial, personal,
+hobby, educational, academic, evaluation and open-source use is free of charge;
+Commercial Use requires a separate commercial license (see LICENSE-BUSL.txt).
+
+The simulator core is a port of avr8js (https://github.com/wokwi/avr8js) by
+Uri Shaked, originally distributed under the MIT License. That original MIT
+copyright and permission notice is retained below and continues to apply to the
+ported portions.
+
+===============================================================================
+MIT License (applies to the avr8js-derived portions of the simulator core)
 
 Copyright (c) 2019-2023 Uri Shaked
 Copyright (c) 2025-present, Iván Montiel

--- a/LICENSE-BUSL.txt
+++ b/LICENSE-BUSL.txt
@@ -3,11 +3,15 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Iván Montiel Cardona
-Licensed Work:        AVR8Sharp BUSL-1.1 components — Avr8Sharp.TestKit and
-                      Avr8Sharp.TestKit.Core.
-                      (The Avr8Sharp simulator core is licensed separately under
-                      MIT; it is a port of the avr8js library, © Uri Shaked.)
+Licensed Work:        AVR8Sharp — the complete AVR-8 simulator: the simulator core
+                      (Avr8Sharp) and every package (Avr8Sharp.TestKit,
+                      Avr8Sharp.TestKit.Core).
                       The Licensed Work is © 2025-2026 Iván Montiel Cardona.
+
+                      The simulator core is a port of the avr8js library
+                      (© Uri Shaked), originally under the MIT License; that MIT
+                      copyright and permission notice is retained in the LICENSE file
+                      and continues to apply to the ported portions.
 Additional Use Grant: You may copy, modify, create derivative works of, redistribute,
                       and make production use of the Licensed Work free of charge for
                       any use that is not a Commercial Use, as defined below.

--- a/src/Avr8Sharp.TestKit.Core/Avr8Sharp.TestKit.Core.csproj
+++ b/src/Avr8Sharp.TestKit.Core/Avr8Sharp.TestKit.Core.csproj
@@ -22,7 +22,7 @@
              nuget.org rejects BUSL-1.1 as a license *expression*, so we ship it as a *file*. -->
         <PackageLicenseExpression></PackageLicenseExpression>
         <PackageLicenseFile>LICENSE-BUSL.txt</PackageLicenseFile>
-        <Version>1.1.0-beta6</Version>
+        <Version>1.1.0-beta7</Version>
         <PackageProjectUrl>https://github.com/begeistert/avr8sharp</PackageProjectUrl>
         <Company>Iván Montiel</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Avr8Sharp.TestKit/Avr8Sharp.TestKit.csproj
+++ b/src/Avr8Sharp.TestKit/Avr8Sharp.TestKit.csproj
@@ -17,7 +17,7 @@
              nuget.org rejects BUSL-1.1 as a license *expression*, so we ship it as a *file*. -->
         <PackageLicenseExpression></PackageLicenseExpression>
         <PackageLicenseFile>LICENSE-BUSL.txt</PackageLicenseFile>
-        <Version>1.1.0-beta6</Version>
+        <Version>1.1.0-beta7</Version>
         <PackageProjectUrl>https://github.com/begeistert/avr8sharp</PackageProjectUrl>
         <Company>Iván Montiel</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Avr8Sharp/Avr8Sharp.csproj
+++ b/src/Avr8Sharp/Avr8Sharp.csproj
@@ -14,8 +14,11 @@
         <Copyright>Copyright (c) Iván Montiel</Copyright>
         <RepositoryUrl>https://github.com/begeistert/avr8sharp</RepositoryUrl>
         <PackageTags>Arduino;AVR;Simulator</PackageTags>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.1.0-beta6</Version>
+        <!-- The whole project is BUSL-1.1 (converts to MIT on the Change Date).
+             nuget.org rejects BUSL-1.1 as an SPDX expression, so we ship it as a *file*. -->
+        <PackageLicenseExpression></PackageLicenseExpression>
+        <PackageLicenseFile>LICENSE-BUSL.txt</PackageLicenseFile>
+        <Version>1.1.0-beta7</Version>
         <PackageProjectUrl>https://github.com/begeistert/avr8sharp</PackageProjectUrl>
         <Company>Iván Montiel</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -24,6 +27,7 @@
 
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\LICENSE-BUSL.txt" Pack="true" PackagePath="" Visible="false" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**The entire AVR8Sharp is BUSL-1.1** (core + all packages), converting to MIT on the Change Date. The `Avr8Sharp` core is no longer MIT. MIT is retained in `LICENSE` only as attribution for the avr8js-derived (© Uri Shaked) core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)