### PR TITLE
Ship the avr8js MIT attribution with every package; release 1.1.0-beta8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,6 +116,14 @@ jobs:
       # Exchanges the workflow's OIDC token for a short-lived nuget.org API key.
       # The trusted-publishing policy (owner + repo + workflow) must exist on
       # nuget.org, and the account username is provided via the NUGET_USER var.
+      # ── Licensing guard ─────────────────────────────────────────────────────
+      #    Nine published versions declared the SPDX expression "MIT", which packs
+      #    no licence file at all — so Uri Shaked's copyright notice, which the MIT
+      #    licence of avr8js requires us to pass on, reached nobody. The repo's
+      #    LICENSE was correct the whole time. Check the artifact, before the push.
+      - name: Verify every package carries its licence and NOTICE
+        run: python3 tools/verify_packages.py ./nupkgs/*.nupkg
+
       - name: NuGet login (Trusted Publishing)
         id: nuget_login
         if: >

--- a/LICENSE
+++ b/LICENSE
@@ -6,16 +6,27 @@ License (the Change License) on the Change Date. Non-commercial, personal,
 hobby, educational, academic, evaluation and open-source use is free of charge;
 Commercial Use requires a separate commercial license (see LICENSE-BUSL.txt).
 
+AVR8Sharp is © 2025-present Iván Montiel Cardona.
+
 The simulator core is a port of avr8js (https://github.com/wokwi/avr8js) by
 Uri Shaked, originally distributed under the MIT License. That original MIT
 copyright and permission notice is retained below and continues to apply to the
-ported portions.
+ported portions. See NOTICE.txt for the full third-party attribution that must
+accompany every redistribution.
+
+Retaining that notice is what the MIT License requires of us; it does not
+license AVR8Sharp to you under the MIT License. The work distributed here — the
+simulator core included — is BUSL-1.1, and the MIT License applies to it only
+from the Change Date onwards, as the Change License. If you want avr8js itself
+under the MIT License, it remains MIT for everyone, independently of this
+project, at https://github.com/wokwi/avr8js.
 
 ===============================================================================
-MIT License (applies to the avr8js-derived portions of the simulator core)
+MIT License (retained attribution for the avr8js-derived portions of the
+simulator core; see the paragraph above — this notice does not make those
+portions available to you under the MIT License before the Change Date)
 
-Copyright (c) 2019-2023 Uri Shaked
-Copyright (c) 2025-present, Iván Montiel
+Copyright (c) 2019-2025 Uri Shaked
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,64 @@
+THIRD-PARTY NOTICES
+===================
+
+This file lists the third-party components incorporated into AVR8Sharp, together
+with their copyright notices and the full text of their licenses.
+
+AVR8Sharp as a whole is licensed under the Business Source License 1.1; see
+LICENSE and LICENSE-BUSL.txt. The components listed below are NOT covered by
+that license — they retain their own permissive licenses, and their notices must
+be reproduced with every redistribution of AVR8Sharp, in source or binary form
+(including any product that bundles or embeds it).
+
+-----------------------------------------------------------------------------
+1. avr8js
+-----------------------------------------------------------------------------
+
+Component:  avr8js — an AVR-8 simulator written in TypeScript.
+Upstream:   https://github.com/wokwi/avr8js
+Author:     Uri Shaked
+License:    MIT License
+
+Scope: the AVR8Sharp simulator core (src/Avr8Sharp) is a hand-written C# port of
+avr8js. The MIT copyright and permission notice below applies to the ported
+portions and is retained here as required by the MIT License.
+
+Retaining that notice is what the MIT License requires of us; it does not
+license AVR8Sharp to you under the MIT License. The work distributed here — the
+simulator core included — is BUSL-1.1, and the MIT License applies to it only
+from the Change Date onwards, as the Change License (see LICENSE-BUSL.txt). If
+you want avr8js itself under the MIT License, it remains MIT for everyone,
+independently of this project, at the upstream URL above.
+
+Copyright and license text, reproduced verbatim from the upstream LICENSE file:
+
+    The MIT License (MIT)
+
+    Copyright (c) 2019-2025 Uri Shaked
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-----------------------------------------------------------------------------
+
+AVR8Sharp embeds no chip ROM images or other third-party binaries, and the NuGet
+packages have no third-party package dependencies to attribute.
+
+The .NET runtime statically linked into the Python bindings' Native AOT library
+is attributed separately in bindings/python/THIRD_PARTY_NOTICES, which ships
+with the Python wheel.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://github.com/PyMCU/avr8sharp/actions/workflows/ci.yml/badge.svg)
 [![NuGet](https://img.shields.io/nuget/v/Avr8Sharp.svg)](https://www.nuget.org/packages/Avr8Sharp)
-![License](https://img.shields.io/badge/license-MIT-blue.svg)
+![License](https://img.shields.io/badge/license-BUSL--1.1-blue.svg)
 ![.NET Version](https://img.shields.io/badge/.NET-10.0-purple)
 
 **Avr8Sharp** is a high-performance emulator for the **AVR 8-bit microcontroller** family,
@@ -161,7 +161,21 @@ public void Firmware_output_matches_expected()
 
 ## License
 
-MIT License — see [LICENSE](LICENSE).
+The entire project — the simulator core included — is licensed under the
+**Business Source License 1.1 (BUSL-1.1)**; see [LICENSE](LICENSE) and
+[LICENSE-BUSL.txt](LICENSE-BUSL.txt) for the full text and parameters.
 
-Based on the original work from [avr8js](https://github.com/wokwi/avr8js) © 2019–present Uri Shaked.  
+Non-commercial, personal, hobby, educational, academic, evaluation and open-source
+use is free of charge. Commercial Use requires a separate commercial license — see
+the Additional Use Grant in [LICENSE-BUSL.txt](LICENSE-BUSL.txt) for what counts as
+Commercial Use.
+
+On the Change Date (**2030-07-11**), the project converts automatically to the
+**MIT License** (the Change License). Each published version gets its own Change
+Date, four years after its release.
+
+Based on the original work from [avr8js](https://github.com/wokwi/avr8js) © 2019–present Uri Shaked,
+distributed under the MIT License; that notice is retained in [LICENSE](LICENSE) and
+[NOTICE.txt](NOTICE.txt), which lists the third-party attribution that must accompany
+every redistribution.  
 C# Port © 2025–present Iván Montiel Cardona.

--- a/bindings/python/LICENSE
+++ b/bindings/python/LICENSE
@@ -8,17 +8,43 @@ License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             Iván Montiel Cardona
-Licensed Work:        avr8sharp (the Python bindings and the Avr8Sharp.Native
-                      and Avr8Sharp.TestKit(.Core) layers of the avr8sharp
-                      repository). The Licensed Work is (c) 2025-present
-                      Iván Montiel Cardona.
-Additional Use Grant: You may make production use of the Licensed Work,
-                      provided such use does not include offering the Licensed
-                      Work to third parties as a hosted or managed service whose
-                      primary value is the AVR emulation or test-harness
-                      functionality of the Licensed Work.
-Change Date:          2029-06-24
-Change License:       Apache License, Version 2.0
+Licensed Work:        avr8sharp — the Python bindings and every layer of the
+                      avr8sharp repository they bundle, including the simulator
+                      core (Avr8Sharp), Avr8Sharp.Native and
+                      Avr8Sharp.TestKit(.Core).
+                      The Licensed Work is © 2025-2026 Iván Montiel Cardona.
+
+                      The simulator core is a port of the avr8js library
+                      (© Uri Shaked), originally under the MIT License; that MIT
+                      copyright and permission notice is retained in the
+                      THIRD_PARTY_NOTICES file and continues to apply to the
+                      ported portions.
+Additional Use Grant: You may copy, modify, create derivative works of, redistribute,
+                      and make production use of the Licensed Work free of charge for
+                      any use that is not a Commercial Use, as defined below.
+
+                      A "Commercial Use" is any of the following:
+                        (a) use of the Licensed Work in an automated build, test,
+                            continuous-integration, or continuous-delivery (CI/CD)
+                            pipeline operated by or on behalf of a for-profit entity;
+                        (b) distribution, sale, sublicensing, hosting, or provision,
+                            for a fee or other commercial consideration, of the Licensed
+                            Work (in whole or in part, modified or unmodified) or of any
+                            product or service that embeds, bundles, or depends on it; or
+                        (c) internal use of the Licensed Work by, or on behalf of, a
+                            for-profit entity to develop, test, or operate a product or
+                            service that generates, or is intended to generate, revenue.
+
+                      For the avoidance of doubt, the following are NOT a Commercial Use
+                      and are always permitted free of charge, provided they do not fall
+                      within (a), (b), or (c) above: use by a natural person acting in a
+                      personal capacity, and use for personal, hobby, educational,
+                      academic-research, evaluation, or open-source purposes.
+
+                      Any Commercial Use requires a separate commercial license from the
+                      Licensor; contact the Licensor to arrange one.
+Change Date:          2030-07-11
+Change License:       MIT
 
 -----------------------------------------------------------------------------
 
@@ -76,5 +102,6 @@ For more information on the use of the Business Source License for the
 avr8sharp project, and on how to use it for your own works, see the README and
 THIRD_PARTY_NOTICES files distributed with the Licensed Work.
 
-The third-party AVR emulation core (derived from avr8js) bundled in this
-package remains under the MIT License; see THIRD_PARTY_NOTICES.
+The AVR emulation core bundled in this package is a port of avr8js, originally
+under the MIT License. The retained MIT copyright and permission notice for the
+ported portions is reproduced in THIRD_PARTY_NOTICES.

--- a/bindings/python/THIRD_PARTY_NOTICES
+++ b/bindings/python/THIRD_PARTY_NOTICES
@@ -2,21 +2,35 @@ THIRD-PARTY NOTICES
 ===================
 
 The avr8sharp wheel bundles a self-contained Native AOT shared library
-(libavr8sharp.{dylib,so} / avr8sharp.dll). That binary statically links the
-following third-party components, whose licenses and notices are reproduced
-below. The avr8sharp Python code and the Avr8Sharp.Native / Avr8Sharp.TestKit
-layers themselves are licensed under the Business Source License 1.1 (see
-LICENSE); the components below are NOT — they retain their own permissive
-licenses.
+(libavr8sharp.{dylib,so} / avr8sharp.dll). This file reproduces the copyright
+notices and licenses of the third-party components incorporated into it.
+
+avr8sharp itself — the Python code and every layer of the C# engine it bundles,
+the emulator core included — is licensed under the Business Source License 1.1
+(see LICENSE), and converts to the MIT License on the Change Date. The notice in
+section 1 below is the upstream attribution the MIT License requires us to
+retain for the ported portions; it does not place those portions under the MIT
+License before the Change Date. The .NET runtime in section 2 is a genuine
+third-party component and retains its own MIT License.
 
 -----------------------------------------------------------------------------
-1. Avr8Sharp emulator core (derived from avr8js)
+1. Avr8Sharp emulator core — retained avr8js attribution
 -----------------------------------------------------------------------------
+
+The Avr8Sharp emulator core is a port of avr8js (https://github.com/wokwi/avr8js)
+by Uri Shaked, originally distributed under the MIT License. That original
+copyright and permission notice is retained below, verbatim from upstream.
+
+Retaining that notice is what the MIT License requires of us; it does not
+license avr8sharp to you under the MIT License. The work distributed here — the
+emulator core included — is BUSL-1.1, and the MIT License applies to it only
+from the Change Date onwards, as the Change License (see LICENSE). If you want
+avr8js itself under the MIT License, it remains MIT for everyone, independently
+of this project, at the upstream URL above.
 
 The MIT License (MIT)
 
-Copyright (c) 2019-2023 Uri Shaked
-Copyright (c) 2025-present Iván Montiel Cardona
+Copyright (c) 2019-2025 Uri Shaked
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -35,8 +35,9 @@ path = "hatch_build.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/avr8sharp"]
-# Ship the MIT third-party notices inside the wheel (license compliance for the bundled core).
-force-include = { "THIRD_PARTY_NOTICES" = "avr8sharp/THIRD_PARTY_NOTICES" }
+# Ship the license and the third-party notices inside the wheel: the BUSL must be displayed on
+# every copy, and the retained avr8js MIT notice must travel with the bundled core.
+force-include = { "THIRD_PARTY_NOTICES" = "avr8sharp/THIRD_PARTY_NOTICES", "LICENSE" = "avr8sharp/LICENSE", "../../NOTICE.txt" = "avr8sharp/NOTICE.txt" }
 # The native library is dropped next to the package by hatch_build.py.
 artifacts = [
     "src/avr8sharp/libavr8sharp.dylib",
@@ -52,3 +53,4 @@ include = [
     "LICENSE",
     "THIRD_PARTY_NOTICES",
 ]
+force-include = { "../../NOTICE.txt" = "NOTICE.txt" }

--- a/src/Avr8Sharp.TestKit.Core/Avr8Sharp.TestKit.Core.csproj
+++ b/src/Avr8Sharp.TestKit.Core/Avr8Sharp.TestKit.Core.csproj
@@ -22,7 +22,7 @@
              nuget.org rejects BUSL-1.1 as a license *expression*, so we ship it as a *file*. -->
         <PackageLicenseExpression></PackageLicenseExpression>
         <PackageLicenseFile>LICENSE-BUSL.txt</PackageLicenseFile>
-        <Version>1.1.0-beta7</Version>
+        <Version>1.1.0-beta8</Version>
         <PackageProjectUrl>https://github.com/begeistert/avr8sharp</PackageProjectUrl>
         <Company>Iván Montiel</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Avr8Sharp.TestKit.Core/Avr8Sharp.TestKit.Core.csproj
+++ b/src/Avr8Sharp.TestKit.Core/Avr8Sharp.TestKit.Core.csproj
@@ -31,6 +31,7 @@
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
         <None Include="..\..\LICENSE-BUSL.txt" Pack="true" PackagePath="" Visible="false" />
+        <None Include="..\..\NOTICE.txt" Pack="true" PackagePath="" Visible="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Avr8Sharp.TestKit/Avr8Sharp.TestKit.csproj
+++ b/src/Avr8Sharp.TestKit/Avr8Sharp.TestKit.csproj
@@ -38,6 +38,7 @@
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
         <None Include="..\..\LICENSE-BUSL.txt" Pack="true" PackagePath="" Visible="false" />
+        <None Include="..\..\NOTICE.txt" Pack="true" PackagePath="" Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/src/Avr8Sharp.TestKit/Avr8Sharp.TestKit.csproj
+++ b/src/Avr8Sharp.TestKit/Avr8Sharp.TestKit.csproj
@@ -17,7 +17,7 @@
              nuget.org rejects BUSL-1.1 as a license *expression*, so we ship it as a *file*. -->
         <PackageLicenseExpression></PackageLicenseExpression>
         <PackageLicenseFile>LICENSE-BUSL.txt</PackageLicenseFile>
-        <Version>1.1.0-beta7</Version>
+        <Version>1.1.0-beta8</Version>
         <PackageProjectUrl>https://github.com/begeistert/avr8sharp</PackageProjectUrl>
         <Company>Iván Montiel</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Avr8Sharp/Avr8Sharp.csproj
+++ b/src/Avr8Sharp/Avr8Sharp.csproj
@@ -28,6 +28,7 @@
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
         <None Include="..\..\LICENSE-BUSL.txt" Pack="true" PackagePath="" Visible="false" />
+        <None Include="..\..\NOTICE.txt" Pack="true" PackagePath="" Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/src/Avr8Sharp/Avr8Sharp.csproj
+++ b/src/Avr8Sharp/Avr8Sharp.csproj
@@ -18,7 +18,7 @@
              nuget.org rejects BUSL-1.1 as an SPDX expression, so we ship it as a *file*. -->
         <PackageLicenseExpression></PackageLicenseExpression>
         <PackageLicenseFile>LICENSE-BUSL.txt</PackageLicenseFile>
-        <Version>1.1.0-beta7</Version>
+        <Version>1.1.0-beta8</Version>
         <PackageProjectUrl>https://github.com/begeistert/avr8sharp</PackageProjectUrl>
         <Company>Iván Montiel</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/tools/verify_packages.py
+++ b/tools/verify_packages.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Fail a release if a package would ship without its licence and third-party notices.
+
+Every version published before 2026-07-17 shipped without them — that is why this
+exists. The failure was silent: the repo's LICENSE and NOTICE.txt were correct, but
+nothing put them inside the .nupkg, and nobody looks inside a .nupkg.
+
+Each packable project must produce a package that carries:
+
+  * <license type="file"> — never an SPDX expression. nuget.org rejects BUSL-1.1 as
+    an expression, and an expression packs no file at all: it just links to the
+    generic SPDX text, which has no copyright line. That is how nine Avr8Sharp
+    versions ended up shipping Uri Shaked's code with his name nowhere in the box.
+  * the licence file the nuspec names.
+  * NOTICE.txt — the attribution the MIT and BSD components oblige us to pass on.
+
+Usage:  python3 tools/verify_packages.py nupkgs/*.nupkg
+"""
+
+import re
+import sys
+import zipfile
+
+REQUIRED = "NOTICE.txt"
+
+
+def check(path):
+    """Return a list of problems with one package. Empty means it is good to ship."""
+    problems = []
+    try:
+        z = zipfile.ZipFile(path)
+    except (zipfile.BadZipFile, OSError) as e:
+        return [f"cannot be read as a package ({e})"]
+
+    names = z.namelist()
+    nuspecs = [n for n in names if n.endswith(".nuspec")]
+    if not nuspecs:
+        return ["contains no .nuspec"]
+
+    nuspec = z.read(nuspecs[0]).decode("utf-8", "replace")
+    m = re.search(r"<license\s+type=\"(\w+)\"\s*>([^<]*)</license>", nuspec)
+
+    if not m:
+        problems.append("declares no <license> at all")
+    elif m.group(1) == "expression":
+        problems.append(
+            f"declares the SPDX expression '{m.group(2)}' instead of a licence file — "
+            "an expression packs no file, so no copyright notice reaches the consumer"
+        )
+    else:
+        licence_file = m.group(2).strip()
+        if licence_file not in names:
+            problems.append(f"names '{licence_file}' as its licence but does not contain it")
+
+    if REQUIRED not in names:
+        problems.append(f"does not contain {REQUIRED}")
+
+    return problems
+
+
+def main(paths):
+    if not paths:
+        raise SystemExit(__doc__)
+
+    failed = False
+    for path in paths:
+        problems = check(path)
+        name = path.split("/")[-1]
+        if problems:
+            failed = True
+            for p in problems:
+                # GitHub Actions renders ::error:: as an annotation; harmless locally.
+                print(f"::error::{name} {p}")
+        else:
+            print(f"ok  {name}")
+
+    if failed:
+        print("::error::refusing to publish: see above. Fix the packaging, not this check.")
+        return 1
+    print(f"\nall {len(paths)} package(s) carry their licence and {REQUIRED}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
The MIT licence requires its copyright and permission notice to be included in **all copies**. Ours were not.

Nine published versions declare the SPDX expression `MIT`, which packages no licence file at all — it only links to the generic SPDX text, which has no copyright line. So Uri Shaked's name, which `LICENSE` in this repo has carried correctly the entire time, reached nobody who installed Avr8Sharp. The current BUSL version fixed the licence but still shipped no notice.

`NOTICE.txt` is new and now ships inside all three packages, reproducing avr8js's notice verbatim from upstream — including the copyright years, which were wrong here (we said 2019-2023; upstream says 2019-2025).

`LICENSE` also had Iván's own copyright *inside* the MIT permission block, which implied that code was available under MIT and contradicted the BUSL. The block now reproduces only Uri's notice, and says plainly that retaining it does not make those portions MIT before the Change Date.

**README said the project was MIT.** It has been BUSL-1.1 in its entirety since July; the badge and the licence section now say so.

**`bindings/python/` carried a different licence from the rest of the repo:** Change License Apache-2.0, Change Date 2029-06-24, a different use grant, and a line asserting the core "remains under the MIT License". It was a June draft the relicense never swept. Now aligned with the root, and the wheel ships `LICENSE` and `NOTICE.txt` instead of only `THIRD_PARTY_NOTICES`.

**A gate so this cannot recur:** `verify_packages.py` reads each artifact between Pack and push and requires a licence file (never an expression) plus `NOTICE.txt`. Verified against nuget.org: it rejects all ten published versions.

Release 1.1.0-beta8. Tests: 505 + 16, green.